### PR TITLE
fix inheritance problems

### DIFF
--- a/src/json-mop.lisp
+++ b/src/json-mop.lisp
@@ -49,5 +49,12 @@
 
 (defclass json-serializable () ())
 
-(defmethod closer-mop:compute-class-precedence-list ((class json-serializable-class))
-  (cons (find-class 'json-serializable) (call-next-method class)))
+(defmethod initialize-instance :around ((class json-serializable-class)
+                                        &rest rest &key direct-superclasses)
+  (apply #'call-next-method
+         class
+         :direct-superclasses
+         (append direct-superclasses (list (find-class 'json-serializable)))
+         rest))
+
+

--- a/src/to-json.lisp
+++ b/src/to-json.lisp
@@ -111,16 +111,19 @@
                    &optional (stream *standard-output*))
   (with-output (stream)
     (with-object ()
-      (loop for slot in (closer-mop:class-direct-slots (class-of object))
-            do (awhen (json-key-name slot)
-                 (handler-case
-                     (encode-object-element
-                      it
-                      (to-json-value
-                       (slot-value object (closer-mop:slot-definition-name slot))
-                       (json-type slot)))
-                   (unbound-slot (condition)
-                     (declare (ignore condition))
-                     (when *encode-unbound-slots*
-                       (encode-object-element it nil))))))))
+      (loop for class in (closer-mop:class-precedence-list (class-of object))
+         do (loop for slot in (closer-mop:class-direct-slots class)
+               when (typep slot 'json-serializable-slot)
+               do (awhen (json-key-name slot)
+                    (handler-case
+                        (encode-object-element
+                         it
+                         (to-json-value
+                          (slot-value object (closer-mop:slot-definition-name slot))
+                          (json-type slot)))
+                      (unbound-slot (condition)
+                        (declare (ignore condition))
+                        (when *encode-unbound-slots*
+                          (encode-object-element it nil)))))))))
   object)
+

--- a/tests/encode-decode.lisp
+++ b/tests/encode-decode.lisp
@@ -59,3 +59,9 @@
   (for-all ((obj (gen-object)))
     (is (= (get-number (get-object obj))
            (get-number (get-object (obj-rt obj)))))))
+
+(test inheritance
+  (let ((child (make-instance 'child))
+        (parent-only (make-instance 'parent)))
+    (is (string= (with-output-to-string (s) (encode child s))
+                 (with-output-to-string (s) (encode parent-only s))))))

--- a/tests/tests.lisp
+++ b/tests/tests.lisp
@@ -53,6 +53,18 @@
            :json-key "obj"))
   (:metaclass json-serializable-class))
 
+;;; as per https://github.com/gschjetne/json-mop/issues/1
+(defclass parent ()
+  ((foo :accessor foo :initarg :foo
+          :initform "Foo"
+          :json-key "foo"))
+  (:metaclass json-serializable-class))
+
+(defclass child (parent)
+    ((bar :accessor bar :initarg :bar
+      :json-key "bar"))
+  (:metaclass json-serializable-class))
+
 (defun json-string (object)
   (with-output-to-string (s)
     (encode object s)))


### PR DESCRIPTION
Hi @gschjetne I have fixed the inheritance problems described in https://github.com/gschjetne/json-mop/issues/1 but more importantly have changed the way 'json-serializable is injected into the class-precedence-list (see commit message for details on why) and instead is is injected as the least significant direct-superclass (so that methods specializing json-serializable would be less specific, this also makes an instance typep to json-serializable)

The test is pretty meh and that's because I don't really understand what the test-class is about and don't use fiveam but I've added it anyways.

[Commit Message]
I changed the c2mp:compute-c-p-l override because it meant that any instance of a class with the metaclass json-serializable-class would
not be (typep instance 'json-serializable) (i don't know exactly why) which on sbcl and ccl
would still allow you to specify json-serializable as a
parameter-specializer, it's not actually correct as:

http://www.lispworks.com/documentation/HyperSpec/Body/07_fb.htm

>Because every valid parameter specializer is also a valid type
 specifier, the function typep can be used during method selection to
 determine whether an argument satisfies a parameter specializer.