### PR TITLE
json-to-clos: initialize inherited slots too

### DIFF
--- a/tests/encode-decode.lisp
+++ b/tests/encode-decode.lisp
@@ -60,8 +60,14 @@
     (is (= (get-number (get-object obj))
            (get-number (get-object (obj-rt obj)))))))
 
-(test inheritance
+(test inheritance-encode
   (let ((child (make-instance 'child))
         (parent-only (make-instance 'parent)))
     (is (string= (with-output-to-string (s) (encode child s))
                  (with-output-to-string (s) (encode parent-only s))))))
+
+(test inheritance-decode
+  (let* ((child (make-instance 'child :foo "hello" :bar "quux"))
+         (child-rt (obj-rt child)))
+    (is (string= (foo child) (foo child-rt)))
+    (is (string= (bar child) (bar child-rt)))))


### PR DESCRIPTION
Initialization of an instance of a CLOS class would only take into account the direct slots declared in the child class and fail to initialize slots in its parent classes.

This commit ensures all slots, including inherited slots, are considered when calling JSON-TO-CLOS with a parameter naming a child class.