### PR TITLE
Fix: pass hash-table value when json-type :any

### DIFF
--- a/src/to-lisp.lisp
+++ b/src/to-lisp.lisp
@@ -35,6 +35,10 @@
   "When the JSON type is :ANY, Pass the VALUE unchanged"
   value)
 
+(defmethod to-lisp-value ((value hash-table) (json-type (eql :any)))
+  "When the JSON type is :ANY, Pass the hash-table VALUE unchanged"
+  value)
+
 (defmethod to-lisp-value ((value string) (json-type (eql :string)))
   "Return the string VALUE"
   value)


### PR DESCRIPTION
Add method to-lisp-value with parameter-specializer hash-table for value and eql-specializer :any for json-type.
This fixes class-not-found-error when processing a hash-table while json-type is :any. 

Closes #8 