### PR TITLE
Fix: json-serializable-class redefinition

### DIFF
--- a/src/json-mop.lisp
+++ b/src/json-mop.lisp
@@ -57,4 +57,11 @@
          (append direct-superclasses (list (find-class 'json-serializable)))
          rest))
 
+(defmethod reinitialize-instance :around ((class json-serializable-class)
+                                          &rest rest &key direct-superclasses)
+  (apply #'call-next-method
+         class
+         :direct-superclasses
+         (append direct-superclasses (list (find-class 'json-serializable)))
+         rest))
 


### PR DESCRIPTION
Add `reinitialize-instance` :around method for class `json-serializable-class`. Now a `json-serializable-class` can be redefined and the class supertypes of its instances still include `json-serializable-class`.

Thanks @phoe for bug reporting

Another way to trigger this problem is when you first load the `json-mop-tests`
```lisp
(asdf:load-system :json-mop-tests)
```
and afterwards force reload with
```lisp
(asdf:load-system :json-mop-tests :force t)
```
If we now try to test with 
```lisp
(fiveam:run-all-tests)
```
then there are `no-applicable-method-error` with `yason:encode`.

Closes #6 
Closes #7 