### PR TITLE
Feat: support asdf:test-system

### DIFF
--- a/json-mop.asd
+++ b/json-mop.asd
@@ -27,6 +27,7 @@
   :depends-on (#:closer-mop
                #:yason
                #:anaphora)
+  :in-order-to ((test-op (test-op "json-mop-tests")))
   :serial t
   :components ((:module "src"
                 :serial t

--- a/tests/json-mop-tests.asd
+++ b/tests/json-mop-tests.asd
@@ -26,6 +26,10 @@
   :license "LGPLv3+"
   :depends-on (#:json-mop
                #:fiveam)
+  :perform (test-op (o s)
+                    (uiop:symbol-call :fiveam '#:run!
+                                      (find-symbol* '#:test-all
+                                                    '#:json-mop-tests)))
   :serial t
   :components ((:file "package")
                (:file "tests")


### PR DESCRIPTION
Now json-mop can be tested with `(asdf:test-system 'json-mop)`.