### PR TITLE
Feat: verbose printing

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ using `json-to-clos` on a stream, string or hash table; a class name;
 and optional initargs for the class. Values decoded from the JSON will
 override values specified in the initargs.
 
+### Verbose printing
+
+By default, json-serializable objects are printed verbosely.
+This means that the JSON resulting from encoding the instance is
+printed in the REPL.
+If you want to turn off verbose printing, you can:
+
+```lisp
+(setf json-mop:*print-verbose* nil)
+```
+See example for details.
+
 ### Example
 
 First, define your classes:
@@ -108,6 +120,11 @@ Let's try creating an instance:
                                  :title "Adventures of Huckleberry Finn"
                                  :year 1884
                                  :fiction t))))
+```
+
+```lisp
+*author*
+;; => #<AUTHOR {"name":"Mark Twain","year_birth":1835,"bibliography":[{"title":"The Gilded Age: A Tale of Today","year_published":1873,"is_fiction":true},{"title":"Life on the Mississippi","year_published":1883,"is_fiction":false},{"title":"Adventures of Huckleberry Finn","year_published":1884,"is_fiction":true}]} {100463F1E3}>
 ```
 
 To turn it into JSON, `encode` it:

--- a/src/json-mop.lisp
+++ b/src/json-mop.lisp
@@ -22,6 +22,8 @@
 
 (in-package #:json-mop)
 
+(defvar *print-verbose* t)
+
 (defclass json-serializable-class (closer-mop:standard-class) ())
 
 (defmethod closer-mop:validate-superclass ((class json-serializable-class)

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -42,6 +42,8 @@
            #:json-to-clos
            ;; Re-export yason:encode
            #:encode
+	   ;; Adjust repl printing
+	   #:*print-verbose*
            ;; Conditions
            #:slot-not-serializable
            #:slot-name

--- a/src/to-json.lisp
+++ b/src/to-json.lisp
@@ -158,3 +158,9 @@
                           (encode-object-element it nil)))))))))
   object)
 
+(defmethod print-object ((object json-serializable) stream)
+  "If *print-verbose* is t, then print a json-serializable
+ class object encoded as JSON to the REPL."
+  (print-unreadable-object (object stream :type t :identity t)
+    (when *print-verbose*
+      (encode object stream))))

--- a/tests/encode-decode.lisp
+++ b/tests/encode-decode.lisp
@@ -94,3 +94,9 @@
          (child-rt (obj-rt child)))
     (is (string= (foo child) (foo child-rt)))
     (is (string= (bar child) (bar child-rt)))))
+
+(test print-object
+  (let ((child (make-instance 'child :foo "hello" :bar "quux")))
+    (is (string= "#<CHILD {\"bar\":\"quux\",\"foo\":\"hello\"}"
+		 (subseq (with-output-to-string (s) (print-object child s))
+			 0 36)))))


### PR DESCRIPTION
- Add print-object for printing json content in the repl
- Can be deactivated by setting *print-verbose* to nil
- Adjust Readme
- Add test

You like the idea @gschjetne ?
You prefer any changes?
- we could set `*print-verbose*` to nil by default?
- maximum for the characters printed at 300 or 500?
